### PR TITLE
filtering out all the browser::collect_frame spans

### DIFF
--- a/src/instrumentation-client.js
+++ b/src/instrumentation-client.js
@@ -10,6 +10,14 @@ Sentry.init({
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,
 
+  integrations: [
+    Sentry.browserTracingIntegration(
+      {
+        ignorePerformanceApiSpans: [/browser::collect_frame/],
+      }
+    ),
+  ],
+
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
 });


### PR DESCRIPTION
<img width="1928" height="811" alt="Screenshot 2025-07-24 at 10 13 05 AM" src="https://github.com/user-attachments/assets/cc1716e5-9255-406d-8efc-5d7d0175a01d" />

User journey with fewer spans